### PR TITLE
Don't constantly retry an invalid endpoint

### DIFF
--- a/lib/openshift/connection.rb
+++ b/lib/openshift/connection.rb
@@ -1,32 +1,56 @@
 require "kubeclient"
 require "openssl"
+require "active_support/core_ext/numeric/time"
 
 module Openshift
-  module Connection
-    class << self
-      def kubernetes(host:, port: 8443, path: "/api", api_version: "v1", token:, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+  class Connection
+    def initialize
+      @connection_failure_time = {}
+    end
 
-        open(host, port, path, api_version, token, verify_ssl)
+    def connect(endpoint_type, host:, port: 8443, token:, verify_ssl: OpenSSL::SSL::VERIFY_NONE, endpoint_retry_minutes: 60)
+      raise "Invalid endpoint type: #{endpoint_type}" unless valid_endpoint_types.include?(endpoint_type)
+
+      last_failure_time = connection_failure_time[endpoint_type]
+      return if last_failure_time && last_failure_time > endpoint_retry_minutes.minutes.ago.utc
+
+      params = connect_params(endpoint_type)
+      params.merge!(:host => host, :port => port, :token => token, :verify_ssl => verify_ssl)
+
+      open(*params.values_at(:host, :port, :path, :api_version, :token, :verify_ssl))
+    rescue => err
+      connection_failure_time[endpoint_type] = Time.now.utc
+      raise
+    end
+
+    private
+
+    attr_accessor :connection_failure_time
+
+    def valid_endpoint_types
+      %w(kubernetes openshift servicecatalog)
+    end
+
+    def connect_params(endpoint_type)
+      case endpoint_type
+      when "kubernetes"
+        {:port => 8443, :path => "/api", :api_version => "v1"}
+      when "openshift"
+        {:port => 8443, :path => "/oapi", :api_version => "v1"}
+      when "servicecatalog"
+        {:port => 8443, :path => "/apis/servicecatalog.k8s.io", :api_version => "v1beta1"}
       end
+    end
 
-      def openshift(host:, port: 8443, path: "/oapi", api_version: "v1", token:, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
-        open(host, port, path, api_version, token, verify_ssl)
-      end
+    def open(host, port, path, api_version, token, verify_ssl)
+      endpoint_uri = URI::HTTPS.build(:host => host, :port => port, :path => path)
 
-      def servicecatalog(host:, port: 8443, path: "/apis/servicecatalog.k8s.io", api_version: "v1beta1", token:, verify_ssl: OpenSSL::SSL::VERIFY_NONE)
-        open(host, port, path, api_version, token, verify_ssl)
-      end
+      options = {
+        :ssl_options  => {:verify_ssl => verify_ssl},
+        :auth_options => {:bearer_token => token}
+      }
 
-      def open(host, port, path, api_version, token, verify_ssl)
-        endpoint_uri = URI::HTTPS.build(:host => host, :port => port, :path => path)
-
-        options = {
-          :ssl_options  => {:verify_ssl => verify_ssl},
-          :auth_options => {:bearer_token => token}
-        }
-
-        Kubeclient::Client.new(endpoint_uri, api_version, options).tap { |c| c.discover }
-      end
+      Kubeclient::Client.new(endpoint_uri, api_version, options).tap { |c| c.discover }
     end
   end
 end


### PR DESCRIPTION
If an endpoint isn't enabled on a host (e.g. servicecatalog) previously
this would retry every 5 seconds to connect which is way too frequently.

This adds a time based retry-limit to prevent the collector from
slamming an endpoint that doesn't exist but still allows for a user to
enable an endpoint while the collector is running and the collector to
pick it up without having to restart the collector.