### PR TITLE
Correct container image source ref

### DIFF
--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -6,7 +6,7 @@ require "topological_inventory-ingress_api-client"
 
 module TopologicalInventory::Openshift
   class Collector
-    def initialize(source, openshift_host, openshift_port, openshift_token, default_limit: 100, poll_time: 30)
+    def initialize(source, openshift_host, openshift_port, openshift_token, default_limit: 50, poll_time: 30)
       self.connection_manager = Connection.new
       self.collector_threads = Concurrent::Map.new
       self.finished          = Concurrent::AtomicBoolean.new(false)

--- a/lib/topological_inventory/openshift/parser/image.rb
+++ b/lib/topological_inventory/openshift/parser/image.rb
@@ -11,7 +11,8 @@ module TopologicalInventory::Openshift
 
         container_image = TopologicalInventoryIngressApiClient::ContainerImage.new(
           parse_base_item(image).merge(
-            :name => image_name
+            :name       => image_name,
+            :source_ref => image.dockerImageReference,
           )
         )
 


### PR DESCRIPTION
We need to collect correct container image source ref and use the
same for the lazy link. Also for images themselves, we collect only
OpenShift image streams, which is only a subset of images. So we
need to collect also images referenced by container statuses.