### PR TITLE
Fixed missing port ENV

### DIFF
--- a/bin/openshift-collector
+++ b/bin/openshift-collector
@@ -13,7 +13,7 @@ def parse_args
   opts = Optimist::options do
     opt :source, "Inventory Source UID", :type => :string, :required => ENV["SOURCE_UID"].nil?, :default => ENV["SOURCE_UID"]
     opt :hostname, "Hostname of the OpenShift master node", :type => :string, :required => ENV["OPENSHIFT_HOSTNAME"].nil?, :default => ENV["OPENSHIFT_HOSTNAME"]
-    opt :port, "Port of the OpenShift master node", :type => :int, :required => false, :default => ENV["OPENSHIFT_PORT"].to_i || 8443
+    opt :port, "Port of the OpenShift master node", :type => :int, :required => false, :default => (ENV["OPENSHIFT_PORT"] || 8443).to_i
     opt :ingress_api, "Hostname of the ingress-api route", :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
     opt :token, "Auth token to the OpenShift cluster", :type => :string, :required => ENV["OPENSHIFT_TOKEN"].nil?, :default => ENV["OPENSHIFT_TOKEN"]
   end


### PR DESCRIPTION
`ENV["OPENSHIFT_PORT"].to_i` evaluates to 0, so the default value was wrong

cc @agrare 