### PR TITLE
InventoryCollectionStorage for building IC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "manageiq-loggers", "~> 0.1.0"
 gem "manageiq-messaging", "~> 0.1.2"
 gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
-gem "topological_inventory-provider_common", :git => "https://github.com/slemrmartin/topological_inventory-provider_common", :branch => "master"
 
 group :development, :test do
   gem "rspec"

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "manageiq-loggers", "~> 0.1.0"
 gem "manageiq-messaging", "~> 0.1.2"
 gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
+gem "topological_inventory-provider_common", :git => "https://github.com/slemrmartin/topological_inventory-provider_common", :branch => "master"
 
 group :development, :test do
   gem "rspec"

--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -1,9 +1,9 @@
 require "concurrent"
+require "topological_inventory/provider_common/collector"
 require "topological_inventory/openshift"
 require "topological_inventory/openshift/logging"
 require "topological_inventory/openshift/connection"
 require "topological_inventory/openshift/parser"
-require "topological_inventory-ingress_api-client"
 
 module TopologicalInventory::Openshift
   class Collector

--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -1,5 +1,5 @@
 require "concurrent"
-require "topological_inventory/provider_common/collector"
+require "topological_inventory-ingress_api-client/collector"
 require "topological_inventory/openshift"
 require "topological_inventory/openshift/logging"
 require "topological_inventory/openshift/connection"

--- a/lib/topological_inventory/openshift/parser.rb
+++ b/lib/topological_inventory/openshift/parser.rb
@@ -11,7 +11,6 @@ require "topological_inventory/openshift/parser/cluster_service_class"
 require "topological_inventory/openshift/parser/cluster_service_plan"
 require "topological_inventory/openshift/parser/service_instance"
 require "topological_inventory-ingress_api-client"
-require "topological_inventory/provider_common/collectors/inventory_collection_storage"
 
 module TopologicalInventory::Openshift
   class Parser
@@ -26,9 +25,9 @@ module TopologicalInventory::Openshift
 
     attr_accessor :collections, :resource_timestamp, :openshift_host, :openshift_port
 
-    def initialize(openshift_host:, openshift_port: 8443 )
+    def initialize(openshift_host:, openshift_port: 8443)
       self.resource_timestamp = Time.now.utc
-      self.collections = TopologicalInventory::ProviderCommon::Collectors::InventoryCollectionStorage.new
+      self.collections = TopologicalInventory::ProviderCommon::Collector::InventoryCollectionStorage.new
       self.openshift_host = openshift_host
       self.openshift_port = openshift_port
     end

--- a/lib/topological_inventory/openshift/parser.rb
+++ b/lib/topological_inventory/openshift/parser.rb
@@ -27,7 +27,7 @@ module TopologicalInventory::Openshift
 
     def initialize(openshift_host:, openshift_port: 8443)
       self.resource_timestamp = Time.now.utc
-      self.collections = TopologicalInventory::ProviderCommon::Collector::InventoryCollectionStorage.new
+      self.collections = TopologicalInventoryIngressApiClient::Collector::InventoryCollectionStorage.new
       self.openshift_host = openshift_host
       self.openshift_port = openshift_port
     end

--- a/lib/topological_inventory/openshift/parser.rb
+++ b/lib/topological_inventory/openshift/parser.rb
@@ -11,6 +11,7 @@ require "topological_inventory/openshift/parser/cluster_service_class"
 require "topological_inventory/openshift/parser/cluster_service_plan"
 require "topological_inventory/openshift/parser/service_instance"
 require "topological_inventory-ingress_api-client"
+require "topological_inventory/provider_common/collectors/inventory_collection_storage"
 
 module TopologicalInventory::Openshift
   class Parser
@@ -26,15 +27,8 @@ module TopologicalInventory::Openshift
     attr_accessor :collections, :resource_timestamp, :openshift_host, :openshift_port
 
     def initialize(openshift_host:, openshift_port: 8443 )
-      entity_types = [:containers, :container_groups, :container_nodes, :container_projects, :container_images,
-                      :container_templates, :service_instances, :service_offerings, :service_plans,
-                      :container_group_tags, :container_node_tags, :container_project_tags, :container_image_tags,
-                      :container_template_tags, :service_offering_tags, :service_offering_icons]
-
       self.resource_timestamp = Time.now.utc
-      self.collections = entity_types.each_with_object({}).each do |entity_type, collections|
-        collections[entity_type] = TopologicalInventoryIngressApiClient::InventoryCollection.new(:name => entity_type, :data => [])
-      end
+      self.collections = TopologicalInventory::ProviderCommon::Collectors::InventoryCollectionStorage.new
       self.openshift_host = openshift_host
       self.openshift_port = openshift_port
     end

--- a/lib/topological_inventory/openshift/parser/cluster_service_class.rb
+++ b/lib/topological_inventory/openshift/parser/cluster_service_class.rb
@@ -15,7 +15,7 @@ module TopologicalInventory::Openshift
         icon_class   = (service_class.spec&.externalMetadata || {})["console.openshift.io/iconClass"]
         @icons_cache << icon_class
 
-        service_offering = TopologicalInventoryIngressApiClient::ServiceOffering.new(
+        service_offering = collections.service_offerings.build(
           :source_ref            => service_class.spec.externalID,
           :name                  => service_class.spec&.externalName,
           :description           => service_class.spec&.description,
@@ -28,7 +28,6 @@ module TopologicalInventory::Openshift
           :service_offering_icon => lazy_find(:service_offering_icons, :source_ref => icon_class)
         )
 
-        collections[:service_offerings].data << service_offering
         parse_service_offering_tags(service_offering.source_ref, service_class.spec&.tags)
 
         service_offering
@@ -44,14 +43,12 @@ module TopologicalInventory::Openshift
 
         return if icons_cache.empty?
 
-        collections[:service_offering_icons].data.concat(
-          icons_cache.map do |icon|
-            TopologicalInventoryIngressApiClient::ServiceOfferingIcon.new(
-              :source_ref => icon,
-              :data       => fetch_icon(icon)
-            )
-          end
-        )
+        icons_cache.map do |icon|
+          collections.service_offering_icons.build(
+            :source_ref => icon,
+            :data       => fetch_icon(icon)
+          )
+        end
       end
 
       private
@@ -74,7 +71,7 @@ module TopologicalInventory::Openshift
         (tags || []).each do |key|
           next if key.empty?
 
-          collections[:service_offering_tags].data << TopologicalInventoryIngressApiClient::ServiceOfferingTag.new(
+          collections.service_offering_tags.build(
             :service_offering => lazy_find(:service_offerings, :source_ref => source_ref),
             :tag              => lazy_find(:tags, :name => key),
             :value            => '',

--- a/lib/topological_inventory/openshift/parser/cluster_service_plan.rb
+++ b/lib/topological_inventory/openshift/parser/cluster_service_plan.rb
@@ -10,17 +10,15 @@ module TopologicalInventory::Openshift
         cluster_service_class_name = service_plan.spec&.clusterServiceClassRef&.name
         service_offering = lazy_find(:service_offerings, :source_ref => service_plan&.spec&.clusterServiceClassRef&.name) if cluster_service_class_name
 
-        service_plan_data = TopologicalInventoryIngressApiClient::ServicePlan.new(
-          :source_ref        => service_plan.spec.externalID,
-          :name              => service_plan.spec.externalName,
-          :description       => service_plan.spec.description,
-          :resource_version  => service_plan.metadata&.resourceVersion,
-          :source_created_at => service_plan.metadata.creationTimestamp,
+        service_plan_data = collections.service_plans.build(
+          :source_ref         => service_plan.spec.externalID,
+          :name               => service_plan.spec.externalName,
+          :description        => service_plan.spec.description,
+          :resource_version   => service_plan.metadata&.resourceVersion,
+          :source_created_at  => service_plan.metadata.creationTimestamp,
           :create_json_schema => service_plan.spec&.instanceCreateParameterSchema,
-          :service_offering  => service_offering,
+          :service_offering   => service_offering,
         )
-
-        collections[:service_plans].data << service_plan_data
 
         service_plan_data
       end

--- a/lib/topological_inventory/openshift/parser/image.rb
+++ b/lib/topological_inventory/openshift/parser/image.rb
@@ -9,14 +9,13 @@ module TopologicalInventory::Openshift
       def parse_image(image)
         image_name = parse_image_name(image)
 
-        container_image = TopologicalInventoryIngressApiClient::ContainerImage.new(
+        container_image = collections.container_images.build(
           parse_base_item(image).merge(
             :name       => image_name,
             :source_ref => image.dockerImageReference,
           )
         )
 
-        collections[:container_images].data << container_image
         parse_image_tags(container_image.source_ref, image.metadata&.labels&.to_h)
         parse_image_tags(container_image.source_ref, image.dockerImageMetadata&.Config&.Labels&.to_h)
 
@@ -32,7 +31,7 @@ module TopologicalInventory::Openshift
 
       def parse_image_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_image_tags].data << TopologicalInventoryIngressApiClient::ContainerImageTag.new(
+          collections.container_image_tags.build(
             :container_image => lazy_find(:container_images, :source_ref => source_ref),
             :tag             => lazy_find(:tags, :name => key),
             :value           => value,

--- a/lib/topological_inventory/openshift/parser/namespace.rb
+++ b/lib/topological_inventory/openshift/parser/namespace.rb
@@ -7,11 +7,10 @@ module TopologicalInventory::Openshift
       end
 
       def parse_namespace(namespace)
-        container_project = TopologicalInventoryIngressApiClient::ContainerProject.new(
+        container_project = collections.container_projects.build(
           parse_base_item(namespace)
         )
 
-        collections[:container_projects].data << container_project
         parse_namespace_tags(container_project.source_ref, namespace.metadata&.labels&.to_h)
 
         container_project
@@ -26,7 +25,7 @@ module TopologicalInventory::Openshift
 
       def parse_namespace_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_project_tags].data << TopologicalInventoryIngressApiClient::ContainerProjectTag.new(
+          collections.container_project_tags.build(
             :container_project => lazy_find(:container_projects, :source_ref => source_ref),
             :tag               => lazy_find(:tags, :name => key),
             :value             => value,

--- a/lib/topological_inventory/openshift/parser/node.rb
+++ b/lib/topological_inventory/openshift/parser/node.rb
@@ -12,7 +12,7 @@ module TopologicalInventory::Openshift
           memory = parse_quantity(node.status.capacity&.memory)
         end
 
-        container_node = TopologicalInventoryIngressApiClient::ContainerNode.new(
+        container_node = collections.container_nodes.build(
           parse_base_item(node).merge(
             :cpus   => cpus,
             :memory => memory,
@@ -20,7 +20,6 @@ module TopologicalInventory::Openshift
           )
         )
 
-        collections[:container_nodes].data << container_node
         parse_node_tags(container_node.source_ref, node.metadata&.labels&.to_h)
 
         container_node
@@ -35,7 +34,7 @@ module TopologicalInventory::Openshift
 
       def parse_node_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_node_tags].data << TopologicalInventoryIngressApiClient::ContainerNodeTag.new(
+          collections.container_node_tags.build(
             :container_node => lazy_find(:container_nodes, :source_ref => source_ref),
             :tag            => lazy_find(:tags, :name => key),
             :value          => value,

--- a/lib/topological_inventory/openshift/parser/pod.rb
+++ b/lib/topological_inventory/openshift/parser/pod.rb
@@ -33,7 +33,7 @@ module TopologicalInventory::Openshift
 
       def parse_pod_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_group_tags].build(
+          collections.container_group_tags.build(
             :container_group => lazy_find(:container_groups, :source_ref => source_ref),
             :tag             => lazy_find(:tags, :name => key),
             :value           => value,

--- a/lib/topological_inventory/openshift/parser/pod.rb
+++ b/lib/topological_inventory/openshift/parser/pod.rb
@@ -9,7 +9,7 @@ module TopologicalInventory::Openshift
       end
 
       def parse_pod(pod)
-        container_group =  TopologicalInventoryIngressApiClient::ContainerGroup.new(
+        container_group = collections.container_groups.build(
           parse_base_item(pod).merge(
             :ipaddress         => pod.status&.podIP,
             :container_node    => lazy_find_node(pod.spec&.nodeName),
@@ -17,8 +17,7 @@ module TopologicalInventory::Openshift
           )
         )
 
-        collections[:container_groups].data << container_group
-        collections[:containers].data.concat(parse_containers(pod))
+        parse_containers(pod)
         parse_pod_tags(container_group.source_ref, pod.metadata&.labels&.to_h)
         parse_pod_tags(container_group.source_ref, pod.entity&.spec&.nodeSelector&.to_h)
 
@@ -34,17 +33,17 @@ module TopologicalInventory::Openshift
 
       def parse_pod_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_group_tags].data << TopologicalInventoryIngressApiClient::ContainerGroupTag.new(
+          collections[:container_group_tags].build(
             :container_group => lazy_find(:container_groups, :source_ref => source_ref),
-            :tag           => lazy_find(:tags, :name => key),
-            :value         => value,
+            :tag             => lazy_find(:tags, :name => key),
+            :value           => value,
           )
         end
       end
 
       def parse_containers(pod)
         pod.spec.containers.map do |container|
-          TopologicalInventoryIngressApiClient::Container.new(
+          collections.containers.build(
             :container_group    => lazy_find(:container_groups, {:source_ref => pod.metadata.uid}),
             :container_image    => lazy_find(:container_images, {:source_ref => container.image}),
             :name               => container.name,

--- a/lib/topological_inventory/openshift/parser/service_instance.rb
+++ b/lib/topological_inventory/openshift/parser/service_instance.rb
@@ -13,15 +13,13 @@ module TopologicalInventory::Openshift
         service_offering = lazy_find(:service_offerings, :source_ref => cluster_service_class_name) if cluster_service_class_name
         service_plan     = lazy_find(:service_plans, :source_ref => cluster_service_plan_name) if cluster_service_plan_name
 
-        service_instance = TopologicalInventoryIngressApiClient::ServiceInstance.new(
+        service_instance = collections.service_instances.build(
           :source_ref        => service_instance.spec.externalID,
           :name              => service_instance.spec.externalName,
           :source_created_at => service_instance.metadata.creationTimestamp,
           :service_offering  => service_offering,
           :service_plan      => service_plan,
         )
-
-        collections[:service_instances].data << service_instance
 
         service_instance
       end

--- a/lib/topological_inventory/openshift/parser/template.rb
+++ b/lib/topological_inventory/openshift/parser/template.rb
@@ -27,7 +27,7 @@ module TopologicalInventory::Openshift
 
       def parse_template_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_template_tags].build(
+          collections.container_template_tags.build(
             :container_template => lazy_find(:container_templates, :source_ref => source_ref),
             :tag                => lazy_find(:tags, :name => key),
             :value              => value,

--- a/lib/topological_inventory/openshift/parser/template.rb
+++ b/lib/topological_inventory/openshift/parser/template.rb
@@ -7,13 +7,12 @@ module TopologicalInventory::Openshift
       end
 
       def parse_template(template)
-        container_template = TopologicalInventoryIngressApiClient::ContainerTemplate.new(
+        container_template = collections.container_templates.build(
           parse_base_item(template).merge(
             :container_project => lazy_find_namespace(template.metadata&.namespace)
           )
         )
 
-        collections[:container_templates].data << container_template
         parse_template_tags(container_template.source_ref, template.metadata&.labels&.to_h)
 
         container_template
@@ -28,7 +27,7 @@ module TopologicalInventory::Openshift
 
       def parse_template_tags(source_ref, tags)
         (tags || {}).each do |key, value|
-          collections[:container_template_tags].data << TopologicalInventoryIngressApiClient::ContainerTemplateTag.new(
+          collections[:container_template_tags].build(
             :container_template => lazy_find(:container_templates, :source_ref => source_ref),
             :tag                => lazy_find(:tags, :name => key),
             :value              => value,


### PR DESCRIPTION
Parser's collection defined as InventoryCollectionStorage method.

`InventoryCollection` and objects are built and defined in similar way as in ManageIQ.

They are using methods `add_collection` and `build`.
But `add_collection` is not neccessary, because list of available collections are defined by models in `TopologicalInventoryIngressApiClient`

* [x] depends on: https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/25