### PR TITLE
Copy over Openshift Operations worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "optimist"
 gem "rake"
 
 gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "master"
+gem "manageiq-messaging", "~> 0.1.2"
+gem 'topological_inventory-api-client',         :git => "https://github.com/eclarizio/topological_inventory-api-client", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "topological_inventory-ingress_api-client", :git => "https://github.com/Mana
 group :development, :test do
   gem "rspec"
   gem "simplecov"
+  gem "webmock"
 end
 
 #

--- a/bin/openshift-operations
+++ b/bin/openshift-operations
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+require "bundler/setup"
+require "topological_inventory/openshift/operations/worker"
+
+queue_host = ENV["QUEUE_HOST"] || "localhost"
+queue_port = ENV["QUEUE_PORT"] || 9092
+
+operations_worker = TopologicalInventory::Openshift::Operations::Worker.new(:host => queue_host, :port => queue_port)
+operations_worker.run

--- a/lib/topological_inventory/openshift/logging.rb
+++ b/lib/topological_inventory/openshift/logging.rb
@@ -1,0 +1,17 @@
+module TopologicalInventory
+  module Openshift
+    class << self
+      attr_writer :logger
+    end
+
+    def self.logger
+      @logger ||= Logger.new(STDOUT, :level => Logger::INFO)
+    end
+
+    module Logging
+      def logger
+        TopologicalInventory::Openshift.logger
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
@@ -1,0 +1,19 @@
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class AuthenticationRetriever
+          def initialize(endpoint_id)
+            @endpoint_id = endpoint_id
+          end
+
+          def process
+            # Without using Rails example:
+            # https://github.com/ManageIQ/topological_inventory-orchestrator/pull/1/files#diff-4743ee12ee7e621468f2e6590de994efR97
+            Authentication.where(:resource_type => "Endpoint", :resource_id => @endpoint_id).first
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
@@ -10,7 +10,7 @@ module TopologicalInventory
           def process
             # Without using Rails example:
             # https://github.com/ManageIQ/topological_inventory-orchestrator/pull/1/files#diff-4743ee12ee7e621468f2e6590de994efR97
-            Authentication.where(:resource_type => "Endpoint", :resource_id => @endpoint_id).first
+            # Authentication.where(:resource_type => "Endpoint", :resource_id => @endpoint_id).first
           end
         end
       end

--- a/lib/topological_inventory/openshift/operations/core/retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/retriever.rb
@@ -1,0 +1,27 @@
+require "topological_inventory-api-client"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class Retriever
+          def initialize(id)
+            @id = id
+            uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
+            TopologicalInventoryApiClient.configure do |config|
+              config.base_path = "#{ENV["PATH_PREFIX"]}/topological-inventory/v0.0/"
+              config.scheme = uri.scheme
+              config.host = "#{uri.host}:#{uri.port}"
+            end
+
+            @api_instance = TopologicalInventoryApiClient::DefaultApi.new
+          end
+
+          def process
+            nil # Override in subclasses
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
@@ -1,0 +1,63 @@
+require "rest_client"
+require "topological_inventory/openshift/operations/core/authentication_retriever"
+require "topological_inventory/openshift/operations/core/service_plan_client"
+require "topological_inventory/openshift/operations/core/source_endpoints_retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class ServiceCatalogClient
+          def initialize(source_id)
+            all_source_endpoints = SourceEndpointsRetriever.new(source_id).process
+            @default_endpoint = all_source_endpoints.data.find { |endpoint| endpoint.default }
+
+            @authentication = AuthenticationRetriever.new(@default_endpoint.id).process
+          end
+
+          def order_service_plan(plan_name, service_offering_name, additional_parameters)
+            payload = ServicePlanClient.new.build_payload(plan_name, service_offering_name, additional_parameters)
+            response = external_request(:post, order_service_plan_url, payload)
+            JSON.parse(response.body)
+          end
+
+          private
+
+          def order_service_plan_url
+            base_url_path = URI::Generic.build(
+              :scheme => @default_endpoint.scheme,
+              :host   => @default_endpoint.host,
+              :port   => @default_endpoint.port,
+              :path   => @default_endpoint.path
+            ).to_s
+            URI.join(base_url_path, "apis/servicecatalog.k8s.io/v1beta1/namespaces/default/serviceinstances").to_s
+          end
+
+          def external_request(method, url, payload, headers = generic_headers)
+            request_options = {
+              :method     => method,
+              :url        => url,
+              :headers    => headers,
+              :verify_ssl => verify_ssl_mode,
+              :payload    => payload
+            }
+
+            RestClient::Request.new(request_options).execute
+          end
+
+          def generic_headers
+            {
+              "Authorization" => "Bearer #{@authentication.password}",
+              "Content-Type"  => "application/json",
+              "Accept"        => "application/json"
+            }
+          end
+
+          def verify_ssl_mode
+            @default_endpoint.verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/service_offering_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_offering_retriever.rb
@@ -1,0 +1,15 @@
+require "topological_inventory/openshift/operations/core/retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class ServiceOfferingRetriever < Retriever
+          def process
+            @api_instance.show_service_offering(@id.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/service_plan_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_plan_client.rb
@@ -1,0 +1,25 @@
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class ServicePlanClient
+          def build_payload(service_plan_name, service_offering_name, order_parameters)
+            {
+              "apiVersion" => "servicecatalog.k8s.io/v1beta1",
+              "kind"       => "ServiceInstance",
+              "metadata"   => {
+                "name"      => "#{service_offering_name}-#{SecureRandom.uuid}",
+                "namespace" => order_parameters[:provider_control_parameters][:namespace]
+              },
+              "spec"       => {
+                "clusterServiceClassExternalName" => service_offering_name,
+                "clusterServicePlanExternalName"  => service_plan_name,
+                "parameters"                      => order_parameters[:service_parameters]
+              }
+            }.to_json
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/service_plan_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_plan_retriever.rb
@@ -1,0 +1,15 @@
+require "topological_inventory/openshift/operations/core/retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class ServicePlanRetriever < Retriever
+          def process
+            @api_instance.show_service_plan(@id.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/source_endpoints_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/source_endpoints_retriever.rb
@@ -1,0 +1,15 @@
+require "topological_inventory/openshift/operations/core/retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class SourceEndpointsRetriever < Retriever
+          def process
+            @api_instance.list_source_endpoints(@id.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/core/source_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/source_retriever.rb
@@ -1,0 +1,15 @@
+require "topological_inventory/openshift/operations/core/retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        class SourceRetriever < Retriever
+          def process
+            @api_instance.show_source(@id.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -38,7 +38,7 @@ module TopologicalInventory
 
         attr_accessor :messaging_client_opts, :client
 
-        def process_message(client, msg)
+        def process_message(_client, msg)
           #TODO: Move to separate module later when more message types are expected aside from just ordering
           context = order_service(msg.payload[:service_plan_id], msg.payload[:order_params])
           update_task(msg.payload[:task_id].to_s, context)

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -1,0 +1,89 @@
+require "manageiq-messaging"
+require "topological_inventory/openshift/logging"
+require "topological_inventory/openshift/operations/core/service_catalog_client"
+require "topological_inventory/openshift/operations/core/service_offering_retriever"
+require "topological_inventory/openshift/operations/core/service_plan_retriever"
+require "topological_inventory/openshift/operations/core/source_retriever"
+require "topological_inventory-api-client"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      class Worker
+        include Logging
+
+        def initialize(messaging_client_opts = {})
+          self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
+        end
+
+        def run
+          # Open a connection to the messaging service
+          self.client = ManageIQ::Messaging::Client.open(messaging_client_opts)
+
+          logger.info("Topological Inventory Openshift Operations worker started...")
+
+          client.subscribe_messages(queue_opts.merge(:max_bytes => 500000)) do |messages|
+            messages.each { |msg| process_message(client, msg) }
+          end
+        ensure
+          client&.close
+        end
+
+        def stop
+          client&.close
+          self.client = nil
+        end
+
+        private
+
+        attr_accessor :messaging_client_opts, :client
+
+        def process_message(client, msg)
+          #TODO: Move to separate module later when more message types are expected aside from just ordering
+          context = order_service(msg.payload[:service_plan_id], msg.payload[:order_params])
+          update_task(msg.payload[:task_id].to_s, context)
+        rescue => e
+          logger.error(e.message)
+          logger.error(e.backtrace.join("\n"))
+          nil
+        end
+
+        def order_service(service_plan_id, order_params)
+          service_plan = Core::ServicePlanRetriever.new(service_plan_id).process
+          source = Core::SourceRetriever.new(service_plan.source_id).process
+          service_offering = Core::ServiceOfferingRetriever.new(service_plan.service_offering_id).process
+
+          catalog_client = Core::ServiceCatalogClient.new(source.id)
+          parsed_response = catalog_client.order_service_plan(service_plan.name, service_offering.name, order_params)
+
+          {
+            :service_instance => {
+              :source_id  => source.id,
+              :source_ref => parsed_response['metadata']['selfLink']
+            }
+          }
+        end
+
+        def update_task(task_id, context)
+          api_instance = TopologicalInventoryApiClient::DefaultApi.new
+          task = TopologicalInventoryApiClient::Task.new("status" => "completed", "context" => context)
+          api_instance.update_task(task_id, task)
+        end
+
+        def queue_opts
+          {
+            :service => "platform.topological-inventory.operations-openshift",
+          }
+        end
+
+        def default_messaging_opts
+          {
+            :protocol   => :Kafka,
+            :client_ref => "openshift-operations-worker",
+            :group_ref  => "openshift-operations-worker",
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,8 @@ end
 
 # For defining kubernetes entities in specs
 require "kubeclient"
-
+require "rspec"
+require "webmock/rspec"
 require "topological_inventory/openshift/collector"
 
 RSpec.configure do |config|

--- a/spec/topological_inventory/openshift/operations/core/authentication_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/authentication_retriever_spec.rb
@@ -1,0 +1,26 @@
+require "topological_inventory/openshift/operations/core/authentication_retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe AuthenticationRetriever do
+          let(:tenant) { Tenant.create! }
+          let(:endpoint) { Endpoint.create!(:tenant => tenant) }
+          let(:subject) { described_class.new(endpoint.id) }
+
+          describe "#process" do
+            let!(:unexpected_authenticaiton) { Authentication.create!(:tenant => tenant) }
+            let!(:expected_authentication) do
+              Authentication.create!(:resource_type => "Endpoint", :resource_id => endpoint.id, :tenant => tenant)
+            end
+
+            it "returns the relevant authentication" do
+              expect(subject.process).to eq(expected_authentication)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/core/authentication_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/authentication_retriever_spec.rb
@@ -5,19 +5,9 @@ module TopologicalInventory
     module Operations
       module Core
         RSpec.describe AuthenticationRetriever do
-          let(:tenant) { Tenant.create! }
-          let(:endpoint) { Endpoint.create!(:tenant => tenant) }
           let(:subject) { described_class.new(endpoint.id) }
 
           describe "#process" do
-            let!(:unexpected_authenticaiton) { Authentication.create!(:tenant => tenant) }
-            let!(:expected_authentication) do
-              Authentication.create!(:resource_type => "Endpoint", :resource_id => endpoint.id, :tenant => tenant)
-            end
-
-            it "returns the relevant authentication" do
-              expect(subject.process).to eq(expected_authentication)
-            end
           end
         end
       end

--- a/spec/topological_inventory/openshift/operations/core/service_catalog_client_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_catalog_client_spec.rb
@@ -1,0 +1,125 @@
+require "topological_inventory/openshift/operations/core/service_catalog_client"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe ServiceCatalogClient do
+          let(:subject) { described_class.new("123") }
+
+          let(:auth) { instance_double("Authentication", :password => "token") }
+
+          let(:source_endpoints_retriever) { instance_double("SourceEndpointsRetriever") }
+          let(:authentication_retriever) { instance_double("AuthenticationRetriever") }
+
+          let(:endpoints_url) { "http://localhost:3000/api/topological-inventory/v0.0/sources/123/endpoints" }
+          let(:endpoints_headers) { {"Content-Type" => "application/json"} }
+          let(:endpoints_api_response) do
+            {
+              "data" => [{
+                "default"    => true,
+                "id"         => 321,
+                "scheme"     => "https",
+                "host"       => "example.com",
+                "verify_ssl" => verify_ssl
+              }]
+            }
+          end
+
+          before do
+            stub_request(:get, endpoints_url).with(:headers => endpoints_headers).to_return(
+              :headers => endpoints_headers, :body => endpoints_api_response.to_json
+            )
+            allow(AuthenticationRetriever).to receive(:new).and_return(authentication_retriever)
+            allow(authentication_retriever).to receive(:process).and_return(auth)
+          end
+
+          around do |e|
+            url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
+            prefix = ENV["PATH_PREFIX"]
+
+            ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
+            ENV["PATH_PREFIX"]               = "api"
+
+            e.run
+
+            ENV["TOPOLOGICAL_INVENTORY_URL"] = url
+            ENV["PATH_PREFIX"]               = prefix
+          end
+
+          describe "#order_service_plan" do
+            let(:url) do
+              URI.join("https://example.com", "apis/servicecatalog.k8s.io/v1beta1/namespaces/default/serviceinstances").to_s
+            end
+            let(:external_dummy_response) { {"metadata" => {"selfLink" => "foo"}} }
+            let(:headers) do
+              {
+                "Authorization" => "Bearer token",
+                "Content-Type"  => "application/json",
+                "Accept"        => "application/json"
+              }
+            end
+            let(:additional_parameters) { {"foo" => "bar", "baz" => "qux"} }
+            let(:service_plan_client) { instance_double("ServicePlanClient") }
+
+            before do
+              allow(ServicePlanClient).to receive(:new).and_return(service_plan_client)
+              allow(service_plan_client).to receive(:build_payload).with(
+                "plan_name", "service_offering_name", additional_parameters
+              ).and_return("payload")
+
+              stub_request(:post, url).with(:body => "payload", :headers => headers)
+              .to_return(:body => external_dummy_response.to_json)
+            end
+
+            context "when verify_ssl is true" do
+              let(:verify_ssl) { true }
+
+              it "passes the correct verify_ssl option to the http handler" do
+                expect(RestClient::Request).to receive(:new).with(hash_including(:verify_ssl => 1)).and_call_original
+                subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
+              end
+
+              it "builds the payload" do
+                expect(service_plan_client).to receive(:build_payload).with(
+                  "plan_name", "service_offering_name", "foo" => "bar", "baz" => "qux"
+                )
+
+                subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
+              end
+
+              it "returns the expected response" do
+                expect(
+                  subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
+                ).to eq(external_dummy_response)
+              end
+            end
+
+            context "when verify_ssl is false" do
+              let(:verify_ssl) { false }
+
+              it "passes the correct verify_ssl option to the http handler" do
+                expect(RestClient::Request).to receive(:new).with(hash_including(:verify_ssl => 0)).and_call_original
+                subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
+              end
+
+              it "builds the payload" do
+                expect(service_plan_client).to receive(:build_payload).with(
+                  "plan_name", "service_offering_name", "foo" => "bar", "baz" => "qux"
+                )
+
+                subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
+              end
+
+              it "returns the expected response" do
+                expect(
+                  subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
+                ).to eq(external_dummy_response)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/core/service_offering_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_offering_retriever_spec.rb
@@ -1,0 +1,43 @@
+require "topological_inventory/openshift/operations/core/service_offering_retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe ServiceOfferingRetriever do
+          let(:subject) { described_class.new(123) }
+
+          describe "#process" do
+            let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/service_offerings/123" }
+            let(:headers) { {"Content-Type" => "application/json"} }
+            let(:dummy_response) { {"name" => "dummy"} }
+
+            before do
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
+            end
+
+            around do |e|
+              url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
+              prefix = ENV["PATH_PREFIX"]
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
+              ENV["PATH_PREFIX"]               = "api"
+
+              e.run
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
+              ENV["PATH_PREFIX"]               = prefix
+            end
+
+            it "returns the service offering response" do
+              service_offering = subject.process
+              expect(service_offering.class).to eq(TopologicalInventoryApiClient::ServiceOffering)
+              expect(service_offering.name).to eq("dummy")
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/topological_inventory/openshift/operations/core/service_plan_client_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_plan_client_spec.rb
@@ -1,0 +1,46 @@
+require "topological_inventory/openshift/operations/core/service_plan_client"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe ServicePlanClient do
+          describe "#build_payload" do
+            let(:order_parameters) do
+              {
+                :service_parameters => service_parameters,
+                :provider_control_parameters => {:namespace => "namespace"}
+              }
+            end
+            let(:service_parameters) { {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE"} }
+            let(:expected_payload) do
+              {
+                "apiVersion" => "servicecatalog.k8s.io/v1beta1",
+                "kind"       => "ServiceInstance",
+                "metadata"   => {
+                  "name"      => "service_offering_name-uuid",
+                  "namespace" => "namespace"
+                },
+                "spec"       => {
+                  "clusterServiceClassExternalName" => "service_offering_name",
+                  "clusterServicePlanExternalName"  => "service_plan_name",
+                  "parameters"                      => service_parameters
+                }
+              }.to_json
+            end
+
+            before do
+              allow(SecureRandom).to receive(:uuid).and_return("uuid")
+            end
+
+            it "returns the payload with the right data" do
+              expect(
+                subject.build_payload("service_plan_name", "service_offering_name", order_parameters)
+              ).to eq(expected_payload)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/core/service_plan_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_plan_retriever_spec.rb
@@ -1,0 +1,42 @@
+require "topological_inventory/openshift/operations/core/service_plan_retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe ServicePlanRetriever do
+          let(:subject) { described_class.new(123) }
+
+          describe "#process" do
+            let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/service_plans/123" }
+            let(:headers) { {"Content-Type" => "application/json"} }
+            let(:dummy_response) { {"name" => "dummy"} }
+
+            before do
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
+            end
+
+            around do |e|
+              url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
+              prefix = ENV["PATH_PREFIX"]
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
+              ENV["PATH_PREFIX"]               = "api"
+
+              e.run
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
+              ENV["PATH_PREFIX"]               = prefix
+            end
+
+            it "returns the service plan response" do
+              service_plan = subject.process
+              expect(service_plan.class).to eq(TopologicalInventoryApiClient::ServicePlan)
+              expect(service_plan.name).to eq("dummy")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/core/source_endpoints_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/source_endpoints_retriever_spec.rb
@@ -1,0 +1,43 @@
+require "topological_inventory/openshift/operations/core/source_endpoints_retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe SourceEndpointsRetriever do
+          let(:subject) { described_class.new(123) }
+
+          describe "#process" do
+            let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/sources/123/endpoints" }
+            let(:headers) { {"Content-Type" => "application/json"} }
+            let(:dummy_response) { {"data" => [{"host" => "dummy"}]} }
+
+            before do
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
+            end
+
+            around do |e|
+              url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
+              prefix = ENV["PATH_PREFIX"]
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
+              ENV["PATH_PREFIX"]               = "api"
+
+              e.run
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
+              ENV["PATH_PREFIX"]               = prefix
+            end
+
+            it "returns the list of endpoints based on the source" do
+              endpoints = subject.process
+              expect(endpoints.class).to eq(TopologicalInventoryApiClient::EndpointsCollection)
+              expect(endpoints.data.first.class).to eq(TopologicalInventoryApiClient::Endpoint)
+              expect(endpoints.data.first.host).to eq("dummy")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/core/source_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/source_retriever_spec.rb
@@ -1,0 +1,42 @@
+require "topological_inventory/openshift/operations/core/source_retriever"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Core
+        RSpec.describe SourceRetriever do
+          let(:subject) { described_class.new(123) }
+
+          describe "#process" do
+            let(:url) { "http://localhost:3000/api/topological-inventory/v0.0/sources/123" }
+            let(:headers) { {"Content-Type" => "application/json"} }
+            let(:dummy_response) { {"name" => "dummy"} }
+
+            before do
+              stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
+            end
+
+            around do |e|
+              url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
+              prefix = ENV["PATH_PREFIX"]
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
+              ENV["PATH_PREFIX"]               = "api"
+
+              e.run
+
+              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
+              ENV["PATH_PREFIX"]               = prefix
+            end
+
+            it "returns the source response" do
+              source = subject.process
+              expect(source.class).to eq(TopologicalInventoryApiClient::Source)
+              expect(source.name).to eq("dummy")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/worker_spec.rb
+++ b/spec/topological_inventory/openshift/operations/worker_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
     let(:headers) { {"Content-Type" => "application/json"} }
 
     before do
+      require "active_support/json"
+      require "active_support/core_ext/object/json" # required to get service_plan.to_json to work properly
+
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
       allow(client).to receive(:subscribe_messages).and_yield(messages)

--- a/spec/topological_inventory/openshift/operations/worker_spec.rb
+++ b/spec/topological_inventory/openshift/operations/worker_spec.rb
@@ -1,0 +1,86 @@
+require "topological_inventory/openshift/operations/worker"
+
+RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
+  let(:client) { double(:client) }
+
+  describe "#run" do
+    let(:messages) { [ManageIQ::Messaging::ReceivedMessage.new(nil, nil, payload, nil)] }
+    let(:task) { double("Task", :id => 1) }
+
+    let(:service_plan) do
+      TopologicalInventoryApiClient::ServicePlan.new(:id                  => "123",
+                                                     :name                => "plan_name",
+                                                     :source_id           => source.id,
+                                                     :service_offering_id => service_offering.id)
+    end
+    let(:source) do
+      TopologicalInventoryApiClient::Source.new(:id => "321")
+    end
+    let(:service_offering) do
+      TopologicalInventoryApiClient::ServiceOffering.new(:id => "456", :name => "service_offering")
+    end
+    let(:payload) { {:service_plan_id => service_plan.id, :order_params => "order_params", :task_id => task.id} }
+
+    let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
+    let(:base_url_path) { "http://localhost:3000/api/topological-inventory/v0.0/" }
+    let(:service_plan_url) { URI.join(base_url_path, "service_plans/#{service_plan.id}").to_s }
+    let(:source_url) { URI.join(base_url_path, "sources/#{source.id}").to_s }
+    let(:service_offering_url) { URI.join(base_url_path, "service_offerings/#{service_offering.id}").to_s }
+    let(:task_url) { URI.join(base_url_path, "tasks/#{task.id}").to_s }
+    let(:headers) { {"Content-Type" => "application/json"} }
+
+    before do
+      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      allow(client).to receive(:close)
+      allow(client).to receive(:subscribe_messages).and_yield(messages)
+
+      stub_request(:get, service_plan_url).with(:headers => headers).to_return(
+        :headers => headers, :body => service_plan.to_json
+      )
+      stub_request(:get, source_url).with(:headers => headers).to_return(
+        :headers => headers, :body => source.to_json
+      )
+      stub_request(:get, service_offering_url).with(:headers => headers).to_return(
+        :headers => headers, :body => service_offering.to_json
+      )
+
+      allow(
+        TopologicalInventory::Openshift::Operations::Core::ServiceCatalogClient
+      ).to receive(:new).with(source.id).and_return(service_catalog_client)
+      allow(service_catalog_client).to receive(:order_service_plan).and_return({'metadata' => {'selfLink' => 'source_ref'}})
+
+      stub_request(:patch, task_url).with(:headers => headers)
+    end
+
+    around do |e|
+      url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
+      prefix = ENV["PATH_PREFIX"]
+
+      ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
+      ENV["PATH_PREFIX"]               = "api"
+
+      e.run
+
+      ENV["TOPOLOGICAL_INVENTORY_URL"] = url
+      ENV["PATH_PREFIX"]               = prefix
+    end
+
+    it "orders the service via the service catalog client" do
+      expect(service_catalog_client).to receive(:order_service_plan).with("plan_name", "service_offering", "order_params")
+      described_class.new.run
+    end
+
+    it "makes a patch request to the update task endpoint with the status and context" do
+      context = {
+        :service_instance => {
+          :source_id  => source.id,
+          :source_ref => "source_ref"
+        }
+      }
+      described_class.new.run
+      expect(
+        a_request(:patch, task_url).with(:body => {"status" => "completed", "context" => context})
+      ).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
This moves the openshift operations worker from https://github.com/ManageIQ/topological_inventory-operations-openshift into this repo which will eventually become `topological_inventory-openshift`