### PR TITLE
Rubocop generated file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ bundler.d/*
 # .ruby-version
 # .ruby-gemset
 
+# generated rubocop file
+.rubocop-https*
+
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc


### PR DESCRIPTION
`rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml`

cc @agrare 