### PR TITLE
Use ManageIQ instead of eclarizio's topological_inventory-api-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rake"
 
 gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "master"
 gem "manageiq-messaging", "~> 0.1.2"
-gem 'topological_inventory-api-client',         :git => "https://github.com/eclarizio/topological_inventory-api-client", :branch => "master"
+gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 
 group :development, :test do


### PR DESCRIPTION
Now that we've moved the topological_inventory-api-client to manageiq, we should use that repository instead of mine :)