### PR TITLE
Use the default host so we don't have to set env vars in specs

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
@@ -18,7 +18,8 @@ module TopologicalInventory
               :host   => host,
               :port   => port,
               :path   => "/internal/v0.0/authentications/#{@id}",
-              :query  => "expose_encrypted_attribute[]=password")
+              :query  => "expose_encrypted_attribute[]=password"
+            )
 
             request_options = {
               :method  => :get,

--- a/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
@@ -9,10 +9,20 @@ module TopologicalInventory
             headers = {
               "Content-Type" => "application/json"
             }
-            url = URI.join(ENV["TOPOLOGICAL_INVENTORY_URL"], "/internal/v0.0/authentications/#{@id}?expose_encrypted_attribute[]=password")
+
+            scheme     = TopologicalInventoryApiClient.configure.scheme
+            host, port = TopologicalInventoryApiClient.configure.host.split(":")
+
+            uri = URI::Generic.build(
+              :scheme => scheme,
+              :host   => host,
+              :port   => port,
+              :path   => "/internal/v0.0/authentications/#{@id}",
+              :query  => "expose_encrypted_attribute[]=password")
+
             request_options = {
               :method  => :get,
-              :url     => url.to_s,
+              :url     => uri.to_s,
               :headers => headers
             }
             response = RestClient::Request.new(request_options).execute

--- a/spec/topological_inventory/openshift/operations/core/authentication_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/authentication_retriever_spec.rb
@@ -9,7 +9,7 @@ module TopologicalInventory
 
           let(:headers) { {"Content-Type" => "application/json"} }
           let(:internal_authentications_url) do
-            "http://localhost:3000/internal/v0.0/authentications/123?expose_encrypted_attribute[]=password"
+            "https://virtserver.swaggerhub.com/internal/v0.0/authentications/123?expose_encrypted_attribute[]=password"
           end
           let(:internal_authentication_response) { {"password" => "token"} }
 
@@ -17,20 +17,6 @@ module TopologicalInventory
             stub_request(:get, internal_authentications_url).with(:headers => headers).to_return(
               :headers => headers, :body => internal_authentication_response.to_json
             )
-          end
-
-          around do |e|
-            url = ENV["TOPOLOGICAL_INVENTORY_URL"]
-            ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-            uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-            TopologicalInventoryApiClient.configure do |config|
-              config.scheme = uri.scheme || "http"
-              config.host = "#{uri.host}:#{uri.port}"
-            end
-
-            e.run
-
-            ENV["TOPOLOGICAL_INVENTORY_URL"] = url
           end
 
           describe "#process" do

--- a/spec/topological_inventory/openshift/operations/core/service_catalog_client_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_catalog_client_spec.rb
@@ -12,7 +12,7 @@ module TopologicalInventory
           let(:source_endpoints_retriever) { instance_double("SourceEndpointsRetriever") }
           let(:authentication_retriever) { instance_double("AuthenticationRetriever") }
 
-          let(:endpoints_url) { "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/sources/123/endpoints" }
+          let(:endpoints_url) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/sources/123/endpoints" }
           let(:endpoints_headers) { {"Content-Type" => "application/json"} }
           let(:endpoints_api_response) do
             {
@@ -26,7 +26,7 @@ module TopologicalInventory
             }
           end
           let(:endpoint_authentications_url) do
-            "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/endpoints/321/authentications"
+            "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/endpoints/321/authentications"
           end
           let(:endpoints_authentications_response) { {"data" => [{"id" => 3210}] } }
 
@@ -39,20 +39,6 @@ module TopologicalInventory
             )
             allow(AuthenticationRetriever).to receive(:new).with("3210").and_return(authentication_retriever)
             allow(authentication_retriever).to receive(:process).and_return(auth)
-          end
-
-          around do |e|
-            url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
-            ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-            uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-            TopologicalInventoryApiClient.configure do |config|
-              config.scheme = uri.scheme || "http"
-              config.host = "#{uri.host}:#{uri.port}"
-            end
-
-            e.run
-
-            ENV["TOPOLOGICAL_INVENTORY_URL"] = url
           end
 
           describe "#order_service_plan" do

--- a/spec/topological_inventory/openshift/operations/core/service_offering_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_offering_retriever_spec.rb
@@ -8,26 +8,12 @@ module TopologicalInventory
           let(:subject) { described_class.new(123) }
 
           describe "#process" do
-            let(:url) { "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/service_offerings/123" }
+            let(:url) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/service_offerings/123" }
             let(:headers) { {"Content-Type" => "application/json"} }
             let(:dummy_response) { {"name" => "dummy"} }
 
             before do
               stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
-            end
-
-            around do |e|
-              url = ENV["TOPOLOGICAL_INVENTORY_URL"]
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-              uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-              TopologicalInventoryApiClient.configure do |config|
-                config.scheme = uri.scheme || "http"
-                config.host = "#{uri.host}:#{uri.port}"
-              end
-
-              e.run
-
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
             end
 
             it "returns the service offering response" do

--- a/spec/topological_inventory/openshift/operations/core/service_plan_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_plan_retriever_spec.rb
@@ -8,26 +8,12 @@ module TopologicalInventory
           let(:subject) { described_class.new(123) }
 
           describe "#process" do
-            let(:url) { "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/service_plans/123" }
+            let(:url) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/service_plans/123" }
             let(:headers) { {"Content-Type" => "application/json"} }
             let(:dummy_response) { {"name" => "dummy"} }
 
             before do
               stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
-            end
-
-            around do |e|
-              url = ENV["TOPOLOGICAL_INVENTORY_URL"]
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-              uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-              TopologicalInventoryApiClient.configure do |config|
-                config.scheme = uri.scheme || "http"
-                config.host = "#{uri.host}:#{uri.port}"
-              end
-
-              e.run
-
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
             end
 
             it "returns the service plan response" do

--- a/spec/topological_inventory/openshift/operations/core/source_endpoints_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/source_endpoints_retriever_spec.rb
@@ -8,26 +8,12 @@ module TopologicalInventory
           let(:subject) { described_class.new(123) }
 
           describe "#process" do
-            let(:url) { "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/sources/123/endpoints" }
+            let(:url) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/sources/123/endpoints" }
             let(:headers) { {"Content-Type" => "application/json"} }
             let(:dummy_response) { {"data" => [{"host" => "dummy"}]} }
 
             before do
               stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
-            end
-
-            around do |e|
-              url = ENV["TOPOLOGICAL_INVENTORY_URL"]
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-              uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-              TopologicalInventoryApiClient.configure do |config|
-                config.scheme = uri.scheme || "http"
-                config.host = "#{uri.host}:#{uri.port}"
-              end
-
-              e.run
-
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
             end
 
             it "returns the list of endpoints based on the source" do

--- a/spec/topological_inventory/openshift/operations/core/source_retriever_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/source_retriever_spec.rb
@@ -8,26 +8,12 @@ module TopologicalInventory
           let(:subject) { described_class.new(123) }
 
           describe "#process" do
-            let(:url) { "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/sources/123" }
+            let(:url) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/sources/123" }
             let(:headers) { {"Content-Type" => "application/json"} }
             let(:dummy_response) { {"name" => "dummy"} }
 
             before do
               stub_request(:get, url).with(:headers => headers).to_return(:body => dummy_response.to_json, :headers => headers)
-            end
-
-            around do |e|
-              url = ENV["TOPOLOGICAL_INVENTORY_URL"]
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-              uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-              TopologicalInventoryApiClient.configure do |config|
-                config.scheme = uri.scheme || "http"
-                config.host = "#{uri.host}:#{uri.port}"
-              end
-
-              e.run
-
-              ENV["TOPOLOGICAL_INVENTORY_URL"] = url
             end
 
             it "returns the source response" do

--- a/spec/topological_inventory/openshift/operations/worker_spec.rb
+++ b/spec/topological_inventory/openshift/operations/worker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
     let(:payload) { {:service_plan_id => service_plan.id, :order_params => "order_params", :task_id => task.id} }
 
     let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
-    let(:base_url_path) { "http://localhost:3000/r/insights/platform/topological-inventory/v0.1/" }
+    let(:base_url_path) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/" }
     let(:service_plan_url) { URI.join(base_url_path, "service_plans/#{service_plan.id}").to_s }
     let(:source_url) { URI.join(base_url_path, "sources/#{source.id}").to_s }
     let(:service_offering_url) { URI.join(base_url_path, "service_offerings/#{service_offering.id}").to_s }
@@ -53,20 +53,6 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
       allow(service_catalog_client).to receive(:order_service_plan).and_return({'metadata' => {'selfLink' => 'source_ref'}})
 
       stub_request(:patch, task_url).with(:headers => headers)
-    end
-
-    around do |e|
-      url    = ENV["TOPOLOGICAL_INVENTORY_URL"]
-      ENV["TOPOLOGICAL_INVENTORY_URL"] = "http://localhost:3000"
-      uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
-      TopologicalInventoryApiClient.configure do |config|
-        config.scheme = uri.scheme || "http"
-        config.host = "#{uri.host}:#{uri.port}"
-      end
-
-      e.run
-
-      ENV["TOPOLOGICAL_INVENTORY_URL"] = url
     end
 
     it "orders the service via the service catalog client" do


### PR DESCRIPTION
Setting the ENV["TOPOLOGICAL_INVENTORY_URL"] in the specs in around {} blocks was causing a lot of duplication.  Just stub requests to the default host as defined by the TopologicalInventoryApi client cleans up a lot of this.