### PR TITLE
Use strings instead of symbol keys since payload is JSON

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/service_plan_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_plan_client.rb
@@ -9,12 +9,12 @@ module TopologicalInventory
               "kind"       => "ServiceInstance",
               "metadata"   => {
                 "name"      => "#{service_offering_name}-#{SecureRandom.uuid}",
-                "namespace" => order_parameters[:provider_control_parameters][:namespace]
+                "namespace" => order_parameters["provider_control_parameters"]["namespace"]
               },
               "spec"       => {
                 "clusterServiceClassExternalName" => service_offering_name,
                 "clusterServicePlanExternalName"  => service_plan_name,
-                "parameters"                      => order_parameters[:service_parameters]
+                "parameters"                      => order_parameters["service_parameters"]
               }
             }.to_json
           end

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -39,9 +39,10 @@ module TopologicalInventory
         attr_accessor :messaging_client_opts, :client
 
         def process_message(_client, msg)
+          logger.info("Processing order service with msg: #{msg.payload}")
           #TODO: Move to separate module later when more message types are expected aside from just ordering
-          context = order_service(msg.payload[:service_plan_id], msg.payload[:order_params])
-          update_task(msg.payload[:task_id].to_s, context)
+          context = order_service(msg.payload["service_plan_id"], msg.payload["order_params"])
+          update_task(msg.payload["task_id"].to_s, context)
         rescue => e
           logger.error(e.message)
           logger.error(e.backtrace.join("\n"))

--- a/spec/topological_inventory/openshift/operations/core/service_plan_client_spec.rb
+++ b/spec/topological_inventory/openshift/operations/core/service_plan_client_spec.rb
@@ -8,8 +8,8 @@ module TopologicalInventory
           describe "#build_payload" do
             let(:order_parameters) do
               {
-                :service_parameters => service_parameters,
-                :provider_control_parameters => {:namespace => "namespace"}
+                "service_parameters"          => service_parameters,
+                "provider_control_parameters" => {"namespace" => "namespace"}
               }
             end
             let(:service_parameters) { {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE"} }

--- a/spec/topological_inventory/openshift/operations/worker_spec.rb
+++ b/spec/topological_inventory/openshift/operations/worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
     let(:service_offering) do
       TopologicalInventoryApiClient::ServiceOffering.new(:id => "456", :name => "service_offering")
     end
-    let(:payload) { {:service_plan_id => service_plan.id, :order_params => "order_params", :task_id => task.id} }
+    let(:payload) { {"service_plan_id" => service_plan.id, "order_params" => "order_params", "task_id" => task.id} }
 
     let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
     let(:base_url_path) { "https://virtserver.swaggerhub.com/r/insights/platform/topological-inventory/v0.1/" }


### PR DESCRIPTION
Should be self explanatory, when testing locally the api-client wasn't able to actually make any api calls because the resulting IDs were nil instead of their actual values, as well as the other parameters that were supposed to be coming in.

@carbonin You should be able to do your end-to-end service ordering test after this is merged.
@agrare Review for me, please? 👍 