### PR TITLE
Use the built-in env vars for the API service name and port

### DIFF
--- a/bin/openshift-operations
+++ b/bin/openshift-operations
@@ -7,10 +7,9 @@ require "topological_inventory/openshift/operations/worker"
 queue_host = ENV["QUEUE_HOST"] || "localhost"
 queue_port = ENV["QUEUE_PORT"] || 9092
 
-uri = URI.parse(ENV["TOPOLOGICAL_INVENTORY_URL"])
 TopologicalInventoryApiClient.configure do |config|
-  config.scheme = uri.scheme || "http"
-  config.host = "#{uri.host}:#{uri.port}"
+  config.scheme = "http"
+  config.host = "#{ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"]}"
 end
 
 operations_worker = TopologicalInventory::Openshift::Operations::Worker.new(:host => queue_host, :port => queue_port)


### PR DESCRIPTION
This is portable across openshift installations and allows us to
not repeat ourselves in the deployment templates

@agrare @eclarizio thoughts on this? As I was writing the template for this I realized that we were going to have to pass in a service name for something that was known in the pod already.

Technically we could be doing this for the other internal services like ingress as well ...