### PR TITLE
Update the manageiq-loggers gem to v0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "optimist"
 gem "rake"
 
 gem "kubeclient", :git => "https://github.com/abonas/kubeclient", :branch => "master"
-gem "manageiq-loggers", "~> 0.1.0"
+gem "manageiq-loggers", "~> 0.1.1"
 gem "manageiq-messaging", "~> 0.1.2"
 gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"


### PR DESCRIPTION
This pulls in the change to stop buffering the logging to STDOUT
for container loggers